### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[![Board Status](https://dev.azure.com/kerimsirbeg/06fd1d8d-c37e-4d9e-b900-75d567aac236/65377a82-3585-4f73-91d2-39e638b05f49/_apis/work/boardbadge/de301a3a-07ac-4cf3-b54b-ef64be855748)](https://dev.azure.com/kerimsirbeg/06fd1d8d-c37e-4d9e-b900-75d567aac236/_boards/board/t/65377a82-3585-4f73-91d2-39e638b05f49/Microsoft.RequirementCategory)
 # Your GitHub Learning Lab Repository for Introducing GitHub
 
 Welcome to **your** repository for your GitHub Learning Lab course. This repository will be used during the different activities that I will be guiding you through. See a word you don't understand? We've included an emoji 📖 next to some key terms. Click on it to see its definition.


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#1](https://dev.azure.com/kerimsirbeg/06fd1d8d-c37e-4d9e-b900-75d567aac236/_workitems/edit/1). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.